### PR TITLE
Fix typos and expose metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/3gpp_compexity/
+/3gpp_complexity/
 *.pkl

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,11 @@
+import numpy as np
+from tspec_metrics_HPC import redundancy_index, cluster_entropy
+
+def test_redundancy_index():
+    X = np.eye(3, dtype=float)
+    assert np.isclose(redundancy_index(X), 1.0)
+
+def test_cluster_entropy():
+    X = np.vstack([np.zeros(2), np.zeros(2), np.ones(2), np.ones(2)])
+    ce = cluster_entropy(X)
+    assert np.isclose(ce, 1.0, atol=1e-5)

--- a/tspec_metrics_2.py
+++ b/tspec_metrics_2.py
@@ -266,7 +266,7 @@ def compute_metrics(X_all: np.ndarray, rel_slice: Dict[str, slice],
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> None:w
+def main() -> None:
     args = parse_args()
 
     # env hyper-params -----------------------------------------------------


### PR DESCRIPTION
## Summary
- fix the `3gpp_complexity` ignore rule
- remove stray character from `main()` in metrics script
- expose metric helper functions in `tspec_metrics_HPC.py`
- correct example commands in HPC script
- add unit tests for redundancy and entropy metrics

## Testing
- `pytest -q` *(fails: command not found)*